### PR TITLE
libvirt_user: Use USER env variable instead of ansible_user

### DIFF
--- a/playbooks/roles/libvirt_user/tasks/enable-user/redhat/main.yml
+++ b/playbooks/roles/libvirt_user/tasks/enable-user/redhat/main.yml
@@ -3,7 +3,7 @@
   become: yes
   become_method: sudo
   user:
-    name: "{{ ansible_user }}"
+    name: "{{ ansible_env.USER }}"
     groups: libvirt,kvm,qemu
     append: yes
   when: 'not only_verify_user|bool'

--- a/playbooks/roles/libvirt_user/tasks/enable-user/suse/main.yml
+++ b/playbooks/roles/libvirt_user/tasks/enable-user/suse/main.yml
@@ -3,7 +3,7 @@
   become: yes
   become_method: sudo
   user:
-    name: "{{ ansible_user }}"
+    name: "{{ ansible_env.USER }}"
     groups: libvirt,kvm,qemu
     append: yes
   when: 'not only_verify_user|bool'


### PR DESCRIPTION
The ansible_user variable is not always defined. Use the USER env
variable instead (through ansible_env).

Link: https://github.com/ansible/ansible/issues/23530
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>