### PR TITLE
kdevops: Install vagrant via RPM for Fedora

### DIFF
--- a/playbooks/roles/install_vagrant/tasks/install-deps/redhat/main.yml
+++ b/playbooks/roles/install_vagrant/tasks/install-deps/redhat/main.yml
@@ -6,15 +6,22 @@
   failed_when: vagrant_present.rc != 0 and vagrant_present.rc != 1
   tags: [ 'vagrant', 'verify' ]
 
-- name: Downlaod vagrant from the latest release and install locally
+- name: Enable the vagrant Fedora repo
   become: yes
   become_method: sudo
-  unarchive:
-    src: https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/vagrant_{{ vagrant_version }}_linux_amd64.zip
-    dest: /usr/local/bin
-    remote_src: yes
+  command: "dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo"
+  args:
+    warn: false
   when:
     - force_install_if_present|bool or vagrant_present.rc != 0
+
+- name: Install latest version of Vagrant
+  become: yes
+  become_method: sudo
+  yum:
+    name: vagrant
+    state: present
+  when: vagrant_present.rc != 0
 
 # This is a major heck, alas, vagrant plugin subset commands do not have any
 # easy way to confirm if a plugin is installed in a straight forward way.


### PR DESCRIPTION
You can't actually use the normal vagrant install on Fedora, you'll get
weird ruby errors that make no sense.  I didn't notice this before
because in all of my twiddling I had rage-installed vagrant from yum and
didn't realize that's what made it work.  Fix this by enabling the
vagrant repo and install vagrant from yum, this way subsequent steps
will actually succeed.

Signed-off-by: Josef Bacik <josef@toxicpanda.com>