### PR TITLE
blktests fixes and one Kconfig change

### DIFF
--- a/kconfigs/workflows/bootlinux/Kconfig
+++ b/kconfigs/workflows/bootlinux/Kconfig
@@ -27,9 +27,9 @@ config BOOTLINUX_TREE_NAME
 
 config BOOTLINUX_TREE
 	string "Linux git tree URL"
-	default "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git" if BOOTLINUX_TREE_LINUS
-	default "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git" if BOOTLINUX_TREE_STABLE
-	default "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git" if BOOTLINUX_TREE_NEXT
+	default "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git" if BOOTLINUX_TREE_LINUS
+	default "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git" if BOOTLINUX_TREE_STABLE
+	default "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git" if BOOTLINUX_TREE_NEXT
 	help
 	  The Linux git tree to use.
 

--- a/playbooks/roles/blktests/tasks/install-base-deps/debian/main.yml
+++ b/playbooks/roles/blktests/tasks/install-base-deps/debian/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Install blktests base tools
+  become: yes
+  become_method: sudo
+  apt:
+    name:
+      - btrfs-progs
+    update_cache: yes

--- a/playbooks/roles/blktests/tasks/install-base-deps/main.yml
+++ b/playbooks/roles/blktests/tasks/install-base-deps/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks to install dependencies for oscheck
+- name: oscheck distribution ospecific setup
+  import_tasks: tasks/install-base-deps/debian/main.yml
+  when: ansible_facts['os_family']|lower == 'debian'

--- a/playbooks/roles/blktests/tasks/install-deps/debian/main.yml
+++ b/playbooks/roles/blktests/tasks/install-deps/debian/main.yml
@@ -57,6 +57,7 @@
       - g++
       - parted
       - libnl-utils
+      - zlib1g-dev
     state: present
     update_cache: yes
   tags: [ 'blktests', 'deps' ]

--- a/playbooks/roles/blktests/tasks/main.yml
+++ b/playbooks/roles/blktests/tasks/main.yml
@@ -10,6 +10,8 @@
       skip: true
   tags: vars
 
+- include: tasks/install-base-deps/main.yml
+
 - include_role:
     name: create_data_partition
   tags: [ 'data_partition' ]

--- a/workflows/blktests/Kconfig
+++ b/workflows/blktests/Kconfig
@@ -143,7 +143,7 @@ config BLKTESTS_DATA
 
 config BLKTRACE_GIT
 	string "The blktrace git tree to clone"
-	default "git://git.kernel.dk/blktrace"
+	default "https://git.kernel.dk/blktrace"
 	help
 	  The blktrace git tree to clone.
 


### PR DESCRIPTION
- The first two commits deals with fixing blktests to run in debian
- The Kconfig fix changes the repos protocol from git to https for better access (as companies generally block 9418 port that is used by git) and for better security.