### PR TITLE
vagrant: do not prefix working folder name to node configs

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -86,8 +86,8 @@ pn_u = project_namespace.upcase
 pn_u = pn_u.tr("-", "_")
 pn_l = pn_l.tr("-", "_")
 
-node_config          = ENV[pn_u + '_VAGRANT_NODE_CONFIG'] ? ENV[pn_u + '_VAGRANT_NODE_CONFIG'] : pn_l + "_nodes.yaml"
-node_config_override = ENV[pn_u + '_VAGRANT_NODE_CONFIG'] ? ENV[pn_u + '_VAGRANT_NODE_CONFIG'] : pn_l + "_nodes_override.yaml"
+node_config          = ENV[pn_u + '_VAGRANT_NODE_CONFIG'] ? ENV[pn_u + '_VAGRANT_NODE_CONFIG'] : "kdevops_nodes.yaml"
+node_config_override = ENV[pn_u + '_VAGRANT_NODE_CONFIG'] ? ENV[pn_u + '_VAGRANT_NODE_CONFIG'] : "kdevops_nodes_override.yaml"
 
 config_data = YAML.load_file(node_config)
 


### PR DESCRIPTION
If kdevops is cloned with a different folder name, make bringup will
expect to find the node config and node override config with working_dir
+ "_nodes.yaml" but scripts/gen_nodes_file.sh creates only
"kdevops_nodes.yaml" which will result in the following error:
```
Line number: 0
Message: Errno::ENOENT: No such file or directory @ rb_sysopen - kdevops_npo2_nodes.yaml
```

Instead of prefixing the working dir name, always use "kdevops_nodes.yaml" and
"kdevops_nodes_override.yaml" if VAGRANT_NODE_CONFIG is not set.

Signed-off-by: Pankaj Raghav <p.raghav@samsung.com>