### PR TITLE
cxl: Add second cxl topology

### DIFF
--- a/playbooks/roles/gen_nodes/defaults/main.yml
+++ b/playbooks/roles/gen_nodes/defaults/main.yml
@@ -46,6 +46,7 @@ libvirt_machine_type: 'pc'
 libvirt_host_passthrough: False
 libvirt_enable_cxl: False
 libvirt_enable_cxl_demo_topo1: False
+libvirt_enable_cxl_demo_topo2: False
 libvirt_nvme_drive_format: 'qcow2'
 
 kdevops_workflows_dedicated_workflow: False

--- a/playbooks/roles/gen_nodes/templates/Vagrantfile.j2
+++ b/playbooks/roles/gen_nodes/templates/Vagrantfile.j2
@@ -281,7 +281,7 @@ Vagrant.configure("2") do |config|
         libvirt.qemuargs :value => "-device"
         libvirt.qemuargs :value => "pxb-pcie,id=pcie.1,bus_nr=32,bus=pcie.0,addr=0x8"
 {% if libvirt_enable_cxl %}
-{% if libvirt_enable_cxl_demo_topo1 %}
+{% if libvirt_enable_cxl_demo_topo1 or libvirt_enable_cxl_demo_topo2 %}
         libvirt.qemuargs :value => "-machine"
         libvirt.qemuargs :value => "cxl=on"
 
@@ -302,6 +302,10 @@ Vagrant.configure("2") do |config|
         libvirt.qemuargs :value => "-device"
         libvirt.qemuargs :value => "cxl-rp,port=0,bus=cxl.0,id=kdevops_cxl_root_port1,chassis=0,slot=2"
 
+	{% if libvirt_enable_cxl_demo_topo2 %}
+		libvirt.qemuargs :value => "-device"
+		libvirt.qemuargs :value => "cxl-rp,port=1,bus=cxl.0,id=kdevops_cxl_root_port2,chassis=0,slot=3"
+	{% endif %}
         libvirt.qemuargs :value => "-device"
         libvirt.qemuargs :value => "cxl-type3,bus=kdevops_cxl_root_port1,memdev=kdevops-cxl-mem1,lsa=kdevops-cxl-lsa1,id=kdevops-cxl-pmem0"
 

--- a/scripts/gen-nodes.Makefile
+++ b/scripts/gen-nodes.Makefile
@@ -60,6 +60,9 @@ GEN_NODES_EXTRA_ARGS += libvirt_enable_cxl='True'
 ifeq (y,$(CONFIG_QEMU_ENABLE_CXL_DEMO_TOPOLOGY_1))
 GEN_NODES_EXTRA_ARGS += libvirt_enable_cxl_demo_topo1='True'
 endif # QEMU_ENABLE_CXL_DEMO_TOPOLOGY_1
+ifeq (y,$(CONFIG_QEMU_ENABLE_CXL_DEMO_TOPOLOGY_2))
+GEN_NODES_EXTRA_ARGS += libvirt_enable_cxl_demo_topo2='True'
+endif # QEMU_ENABLE_CXL_DEMO_TOPOLOGY_2
 endif # CONFIG_QEMU_ENABLE_CXL
 
 endif # CONFIG_LIBVIRT_MACHINE_TYPE_Q35

--- a/vagrant/Kconfig
+++ b/vagrant/Kconfig
@@ -1048,15 +1048,24 @@ choice
 	default QEMU_ENABLE_CXL_DEMO_TOPOLOGY_1
 
 config QEMU_ENABLE_CXL_DEMO_TOPOLOGY_1
-	bool "First CXL demo topology - CXL Type 3 device"
+	bool "First CXL demo topology with a CXL Type 3 device"
 	help
-	  This is a basic CXL demo topology with just one directly attached CXL
-	  Type 3 device. The kernel CXL core will consume the resource exposed
+	  This is a basic CXL demo topology. It consists of single host brige that
+	  has one root port. A Type 3 persistent memory device is attached to the
+	  root port. This topology is referred to as a passthrough decoder in
+	  kernel terminology. The kernel CXL core will consume the resource exposed
 	  in the ACPI CXL memory layout description, such as Host Managed
 	  Device memory (HDM), CXL Early Discovery Table (CEDT), and the
 	  CXL Fixed Memory Window Structures to publish the root of a
 	  cxl_port decode hierarchy to map regions that represent System RAM,
 	  or Persistent Memory regions to be managed by LIBNVDIMM.
+
+config QEMU_ENABLE_CXL_DEMO_TOPOLOGY_2
+	bool "Host bridge with two root ports"
+	help
+	  This topology extends the first demo topology by placing two root ports
+	  in the host bridge. This ensures that the decoder associated with the
+	  host bridge is not a passthrough decoder.
 
 endchoice
 


### PR DESCRIPTION
Add another root port to a single host bridge. A single persistent memdev is connected to one of the root ports. This extends the first demo topology. Note that the first demo topology represents a passthrough decoder in kernel speak. The topology added in this commit is no longer passthrough because the hostbridge has two root ports.

Signed-off-by: Adam Manzanares <a.manzanares@samsung.com>